### PR TITLE
Adding conversion tests

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from argparse import ArgumentParser
-from ttk2.formats import guess_format
+from ttk2.conversion import convert
+
 
 def main():
 	import sys
@@ -11,48 +12,7 @@ def main():
 	arguments.add_argument("outfile", nargs=1)
 	arguments.add_argument("infile", nargs="+")
 	args = arguments.parse_args(sys.argv[1:])
-
-	instores = []
-	for path in args.infile:
-		cls = guess_format(path)
-		store = cls()
-		with open(path, "r") as f:
-			store.read(f, lang="todo")
-		instores.append(store)
-
-	if args.template:
-		path = args.template[0]
-		cls = guess_format(path)
-		template = cls()
-		with open(path, "r") as f:
-			template.read(f, lang="todo")
-	else:
-		template = None
-
-	# Create the outgoing store
-	outstore = guess_format(args.outfile[0])()
-	for store in instores:
-		for unit in store.units:
-			outstore.units.append(unit)
-
-	if template:
-		tunits = []
-		for unit in template.units:
-			unit.propkey = unit.key
-			unit.key = unit.value
-			unit.value = ""
-			tunits.append(unit)
-
-		for unit in outstore.units:
-			for tunit in tunits:
-				if unit.key == tunit.propkey:
-					tunit.value = unit.value
-
-		outstore.units = tunits
-
-	with open(args.outfile[0], "w") as f:
-		f.write(outstore.serialize())
-
+	convert(args.outfile[0], args.infile, template=args.template)
 
 if __name__ == "__main__":
 	main()

--- a/test/expected_output_files/output.json
+++ b/test/expected_output_files/output.json
@@ -1,0 +1,1 @@
+{"Key_1": "Value_1", "Key_2": "Value_2", "Key_3": "Value_3"}

--- a/test/expected_output_files/output.po
+++ b/test/expected_output_files/output.po
@@ -1,0 +1,12 @@
+# 
+msgid ""
+msgstr ""
+
+msgid "Key_1"
+msgstr "Value_1"
+
+msgid "Key_2"
+msgstr "Value_2"
+
+msgid "Key_3"
+msgstr "Value_3"

--- a/test/expected_output_files/output.properties
+++ b/test/expected_output_files/output.properties
@@ -1,0 +1,3 @@
+Key_1 = Value_1
+Key_2 = Value_2
+Key_3 = Value_3

--- a/test/expected_output_files/output.tmx
+++ b/test/expected_output_files/output.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tmx version="1.4">
+	<header datatype="PlainText" o-tmf="utf-8" segtype="sentence"/>
+	<body>
+		<tu>
+			<tuv xml:lang="todo">
+				<seg>Value_1</seg>
+			</tuv>
+		</tu>
+		<tu>
+			<tuv xml:lang="todo">
+				<seg>Value_2</seg>
+			</tuv>
+		</tu>
+		<tu>
+			<tuv xml:lang="todo">
+				<seg>Value_3</seg>
+			</tuv>
+		</tu>
+	</body>
+</tmx>

--- a/test/expected_output_files/output.ts
+++ b/test/expected_output_files/output.ts
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS language="todo" version="2.1">
+	<context>
+		<name/>
+		<message>
+			<source>Key_1</source>
+			<translation>Value_1</translation>
+		</message>
+		<message>
+			<source>Key_2</source>
+			<translation>Value_2</translation>
+		</message>
+		<message>
+			<source>Key_3</source>
+			<translation>Value_3</translation>
+		</message>
+	</context>
+</TS>

--- a/test/input_files/input.json
+++ b/test/input_files/input.json
@@ -1,0 +1,5 @@
+{
+    "Key_1": "Value_1",
+    "Key_2": "Value_2",
+    "Key_3": "Value_3"
+}

--- a/test/input_files/input.properties
+++ b/test/input_files/input.properties
@@ -1,0 +1,3 @@
+Key_1=Value_1
+Key_2=Value_2
+Key_3=Value_3

--- a/test_main.py
+++ b/test_main.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 import argparse
+import filecmp
 import logging
+import os
 from io import StringIO
+from ttk2.conversion import convert
 from ttk2.formats import Unit, POStore, TSStore
 
 
 # The idea of this list is to reuse the API of the different implementations
 # so we can test all at once if possible
 _IMPLEMENTED_STORES = [POStore, TSStore]
+_CACHE_MASK = "test/cache."
+_INPUT_MASK = "test/input_files/input."
+_EXPECTED_OUTPUT_MASK = "test/expected_output_files/output."
 
 
 def test_single_unit():
@@ -28,6 +34,54 @@ def test_single_unit():
 		assert parsed_unit.value == unit.value
 
 
+def test_convert_json_to_po():
+	_generic_test_conversion("json", "po")
+
+
+def test_convert_json_to_properties():
+	_generic_test_conversion("json", "properties")
+
+
+def test_convert_json_to_tmx():
+	_generic_test_conversion("json", "tmx")
+
+
+def test_convert_json_to_ts():
+	_generic_test_conversion("json", "ts")
+
+
+def test_convert_properties_to_json():
+	_generic_test_conversion("properties", "json")
+
+
+def test_convert_properties_to_po():
+	_generic_test_conversion("properties", "po")
+
+
+def test_convert_properties_to_tmx():
+	_generic_test_conversion("properties", "tmx")
+
+
+def test_convert_properties_to_ts():
+	_generic_test_conversion("properties", "ts")
+
+
+def teardown_module():
+	"""Clean the cache files after all the tests have been run."""
+	for file_path in os.listdir("test"):
+		if "cache." in file_path:
+			os.remove("test/" + file_path)
+
+
+def _generic_test_conversion(input_ext, output_ext):
+	"""Check the conversion from a format to another one."""
+	output = _CACHE_MASK + output_ext
+	expected = _EXPECTED_OUTPUT_MASK + output_ext
+	inputs = [_INPUT_MASK + input_ext]
+	convert(output, inputs)
+	assert filecmp.cmp(output, expected)
+
+
 def main():
 	parser = argparse.ArgumentParser()
 	parser.add_argument("-d", "--debug",
@@ -42,6 +96,7 @@ def main():
 	for name, f in globals().items():
 		if name.startswith("test_") and callable(f):
 			f()
+	teardown_module()
 
 
 if __name__ == "__main__":

--- a/ttk2/conversion.py
+++ b/ttk2/conversion.py
@@ -1,5 +1,6 @@
-from ttk2.formats import guess_format
 import logging
+from ttk2.formats import guess_format
+
 
 def convert(outfile, infile_list, template=None):
 	"""

--- a/ttk2/conversion.py
+++ b/ttk2/conversion.py
@@ -1,0 +1,54 @@
+from ttk2.formats import guess_format
+import logging
+
+def convert(outfile, infile_list, template=None):
+	"""
+	Parse a list of config files, merge them and write the result in the desired output file.
+
+	In the beginning, check that infile_list is not a single string, otherwise we would iterate
+	over the string characters. If this is indeed a string, log a warning and create a list with
+	this one element to keep going.
+	"""
+	if isinstance(infile_list, str):
+		infile_list = [infile_list]
+		logging.warning("Convert should be provided with a LIST of input files.")
+
+	instores = []
+	for path in infile_list:
+		cls = guess_format(path)
+		store = cls()
+		with open(path, "r") as input_file:
+			store.read(input_file, lang="todo")
+		instores.append(store)
+
+	if template:
+		path = template[0]
+		cls = guess_format(path)
+		template_cls = cls()
+		with open(path, "r") as template_file:
+			template_file.read(template_file, lang="todo")
+	else:
+		template_cls = None
+
+	outstore = guess_format(outfile)()
+	for store in instores:
+		for unit in store.units:
+			outstore.units.append(unit)
+
+	if template_cls:
+		tunits = []
+		for unit in template_cls.units:
+			unit.propkey = unit.key
+			unit.key = unit.value
+			unit.value = ""
+			tunits.append(unit)
+
+		for unit in outstore.units:
+			for tunit in tunits:
+				if unit.key == tunit.propkey:
+					tunit.value = unit.value
+
+		outstore.units = tunits
+
+	with open(outfile, "w") as output_file:
+		output_file.write(outstore.serialize())


### PR DESCRIPTION
In response to issue https://github.com/translate/python-ttk2/issues/2.
Related to my application for the job of Localization Developer at TranslateHouse.

First I did some minor fixes, like adding a gitignore file. Then, I moved the conversion algorithm into a separate function, so that it would be easier to test it independently from the possible command-line issues. Finally, I added some pytest compatible tests (please see the attached file). My next step would be to create a generic test function that would take the output and input formats as arguments. Then it would be easy to cover more conversions between various formats. Also, depending on the test strategy, I could be interesting to use StringIO instead of real disk I/O.

Please feel free to criticize those modifications, I would be happy to improve my code, or to look at another issue!
